### PR TITLE
update likecoin prefix

### DIFF
--- a/misc/connectableChains.ts
+++ b/misc/connectableChains.ts
@@ -93,7 +93,7 @@ const connectableChains = {
     name: 'Likecoin',
     ledgerAppDisplayName: 'Likecoin (LIKE)',
     image: '/static/images/cryptocurrencies/likecoin.png',
-    prefix: 'cosmos',
+    prefix: 'like',
     coinType: 118,
     ledgerAppNames: ['cosmos'],
     chainId: 'likecoin-mainnet-2',


### PR DESCRIPTION
after v2.0.0 upgrade, likecoin chain now default to `like` prefix