### PR TITLE
fix(#682): Fix Proposal details crashing

### DIFF
--- a/components/ProposalDetail/index.tsx
+++ b/components/ProposalDetail/index.tsx
@@ -90,6 +90,13 @@ const ProposalDetail: React.FC<ProposalDetailProps> = ({
   const { t, lang } = useTranslation('common')
   const [voteDialogOpen, setVoteDialogOpen] = React.useState(false)
 
+  const cleanedProposalDescription = React.useMemo(() => {
+    if (proposal && proposal.description) {
+      return proposal.description.replace(/\\n\s?/g, '<br/>').replace('#', '') || ''
+    }
+    return ''
+  }, [proposal])
+
   return (
     <>
       <Card className={classes.card}>
@@ -151,12 +158,7 @@ const ProposalDetail: React.FC<ProposalDetailProps> = ({
                 </Grid>
                 <Grid item xs={10}>
                   <Typography variant="subtitle1" display="inline">
-                    <Markdown>
-                      {(proposal && proposal.description.replace(/\\n\s?/g, '<br/>')).replace(
-                        '#',
-                        ''
-                      ) || ''}
-                    </Markdown>
+                    <Markdown>{cleanedProposalDescription}</Markdown>
                   </Typography>
                 </Grid>
                 {/* Software Upgrade Proposal */}


### PR DESCRIPTION
This PR fixes the crash that occurs when users try to view `ProposalDetails`.

Closes #682, #654

The crash was caused by unsafe code that was meant to fix some formatting issues in the markdown content in the proposal details.

As for the other issue where proposals appear `Invalid`, that does not appear to be caused by the frontend code, as it displays the status according to the value received from graphql.