### PR TITLE
fix(#684): Fix crashing when undelegating

### DIFF
--- a/components/UndelegateDialog/SelectValidators.tsx
+++ b/components/UndelegateDialog/SelectValidators.tsx
@@ -12,6 +12,7 @@ import {
 } from '@material-ui/core'
 import useTranslation from 'next-translate/useTranslation'
 import React from 'react'
+import _ from 'lodash'
 import useStyles from './styles'
 import { formatCrypto, formatCurrency, formatTokenAmount } from '../../misc/utils'
 import { useGeneralContext } from '../../contexts/GeneralContext'
@@ -33,7 +34,12 @@ const SelectValidators: React.FC<SelectValidatorsProps> = ({
   crypto,
   loading,
 }) => {
-  const { amount: totalAmount, price } = Object.values(availableAmount)[0]
+  const delegatedAmount = React.useMemo(() => {
+    return Object.values(availableAmount)[0]
+  }, [availableAmount])
+
+  const totalAmount = _.get(delegatedAmount, 'amount', 1)
+  const price = _.get(delegatedAmount, 'price')
   const { t, lang } = useTranslation('common')
   const classes = useStyles()
   const { currency, currencyRate, hideAmount } = useGeneralContext()


### PR DESCRIPTION
This PR fixes the crashing that occurs when undelegating.

Closes #684 

The crash occurs when the user undelegates all the staked tokens from a validator. 

The reason behind the crash is a null error that happens when the app updates the user's staked tokens following an undelegation action. In this case, the `Undelegate` window does not close fast enough, and tries to reference the staked amount for the validator that the user was trying to undelegate from, resulting in a crash as those staked tokens technically do not exist anymore, as they have been undelegated.