### PR TITLE
fix(AddressBook): network name defaulting to DSM

### DIFF
--- a/components/AddAddressDialog/index.tsx
+++ b/components/AddAddressDialog/index.tsx
@@ -131,7 +131,7 @@ const AddAddressDialog: React.FC<AddAddressDialogProps> = ({ open, onClose }) =>
                     placeholder={t('select network')}
                     inputProps={{
                       ...inputProps,
-                      value: `${Object.values(cryptocurrencies)[0].name}`,
+                      value: `${cryptocurrencies[editedAddress.crypto].name}`,
                     }}
                     // eslint-disable-next-line react/jsx-no-duplicate-props
                     InputProps={{


### PR DESCRIPTION
This PR fixes a UI bug where when adding a new address, the selected network name would default to DSM.