### PR TITLE
fix(#645): validator name overflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   Lint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   tests:
@@ -19,7 +19,7 @@ jobs:
         uses: technote-space/get-diff-action@v6.1.2
         id: git_diff
         with:
-          PATTERNS: +(src|__tests__)/**/*.+(js|jsx|ts|tsx)
+          PATTERNS: +(src|__tests__|**)/**/*.+(js|jsx|ts|tsx)
           FILES: |
             package.json
             yarn.lock

--- a/components/ValidatorAvatar/index.tsx
+++ b/components/ValidatorAvatar/index.tsx
@@ -65,8 +65,8 @@ const ValidatorAvatar: React.FC<ValidatorAvatarProps> = ({
     >
       <Box display="flex" alignItems="center">
         <Avatar className={avatarClass} alt={validator.name} src={validator.image} />
-        <Box ml={1}>
-          <Link className={classes.wrapText} color="primary" variant={titleVariant}>
+        <Box className={classes.wrapText} ml={1}>
+          <Link color="primary" variant={titleVariant}>
             {validator.name}
           </Link>
           {withCommission ? (

--- a/components/ValidatorAvatar/styles.ts
+++ b/components/ValidatorAvatar/styles.ts
@@ -11,7 +11,6 @@ const useStyles = makeStyles(
       height: theme.spacing(7),
     },
     wrapText: {
-      maxWidth: theme.spacing(18),
       textOverflow: 'ellipsis',
       whiteSpace: 'unset',
       overflow: 'hidden',


### PR DESCRIPTION
## Description

Closes: #645

This PR fixes the validator name overflow that occurs on the staking page when the validator name is too long.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
